### PR TITLE
MET-1027 broken search box in clone into model

### DIFF
--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/catalogueElementPicker.coffee
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/catalogueElementPicker.coffee
@@ -26,7 +26,7 @@ catalogueElementPicker.directive 'catalogueElementPicker',  ['$compile', 'modelC
       if statusAttr
         params.status = statusAttr
 
-      if $state.params.dataModelId and $state.params.dataModelId != 'catalogue'
+      if not globalAttr and $state.params.dataModelId and $state.params.dataModelId != 'catalogue'
         params.dataModel = $state.params.dataModelId
 
       if (value)


### PR DESCRIPTION
now the catalogue element picker searches globally even in the simple input when the flag is set