### PR TITLE
Fix: Treating legacy types as equivalents in current version of Model…

### DIFF
--- a/ModelCatalogueCorePlugin/grails-app/domain/org/modelcatalogue/core/CatalogueElement.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/domain/org/modelcatalogue/core/CatalogueElement.groovy
@@ -297,6 +297,11 @@ abstract class  CatalogueElement implements Extendible<ExtensionValue>, Publishe
         if (resourceName.contains('_')) {
             resourceName = resourceName.substring(0, resourceName.indexOf('_'))
         }
+        if (resourceName == 'org.modelcatalogue.core.ValueDomain') {
+            resourceName = 'org.modelcatalogue.core.DataType'
+        } else if (resourceName == 'org.modelcatalogue.core.Classification') {
+            resourceName = 'org.modelcatalogue.core.DataModel'
+        }
         resourceName
     }
 


### PR DESCRIPTION
… Catalogue. Was throwing an error in a method calling the fixResourceName method.