### PR TITLE
MET-1071 custom metadata are shown in table in order to fit the long unbreakable text

### DIFF
--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/mc/core/ui/detail-sections/templates/customMetadata.tpl.html
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/mc/core/ui/detail-sections/templates/customMetadata.tpl.html
@@ -1,0 +1,21 @@
+<div class="col-md-12">
+  <table class="table table-responsive table-condensed table-borderless table-inline table-no-margin"
+         ng-if="!editableForm.$visible">
+    <tbody>
+      <tr ng-repeat="value in customMetadata.values">
+        <td class="text-wrap">
+          <strong class="small">{{value.key}}</strong>
+        </td>
+        <td>
+          <small>{{value.value}}</small>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="row">
+    <div class="custom-metadata col-md-12" ng-if="editableForm.$visible">
+      <ordered-map-editor object="customMetadata"></ordered-map-editor>
+    </div>
+  </div>
+</div>

--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/detailSections.coffee
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/detailSections.coffee
@@ -31,23 +31,12 @@ metadataEditors.run ['$templateCache', ($templateCache) ->
       <div class="full-width-editable col-md-9" ng-if="element.modelCatalogueId &amp;&amp; element.modelCatalogueId != element.internalModelCatalogueId"><a class="small" ng-href="{{element.modelCatalogueId}}" editable-text="copy.modelCatalogueId">{{element.modelCatalogueId}}</a></div>
   '''
 
-  $templateCache.put 'modelcatalogue/core/ui/detailSections/customMetadata.html', '''
-      <div class="col-md-3" ng-repeat-start="value in (editableForm.$visible ? [] : customMetadata.values)">
-          <strong class="small">{{value.key}}</strong>
-      </div>
-      <div class="col-md-9 preserve-new-lines" ng-repeat-end><small>{{value.value}}</small></div>
-      <div class="custom-metadata col-md-12" ng-if="editableForm.$visible">
-          <ordered-map-editor object="customMetadata"></ordered-map-editor>
-      </div>
-  '''
-
   $templateCache.put 'modelcatalogue/core/ui/detailSections/revisionNotes.html', '''
       <div class="col-md-3">
           <strong class="small">Revision Notes</strong>
       </div>
       <div class="full-width-editable col-md-9 preserve-new-lines"><small editable-textarea="copy.revisionNotes" e-rows="5" e-cols="1000">{{element.revisionNotes || 'empty'}}</small></div>
   '''
-
 
   $templateCache.put 'modelcatalogue/core/ui/detailSections/description.html', '''
       <div class="col-md-3">
@@ -380,7 +369,7 @@ x in ['apple', 'banana', 'cherry']
       'dataClass'
     ]
     keys: []
-    template: 'modelcatalogue/core/ui/detailSections/customMetadata.html'
+    template: '/mc/core/ui/detail-sections/customMetadata.html'
   }
 
   reorderInDetail = (relationName) ->

--- a/ModelCatalogueCorePlugin/grails-app/assets/stylesheets/modelcatalogue/core/ui/bs/bootstrap/custom/tables.less
+++ b/ModelCatalogueCorePlugin/grails-app/assets/stylesheets/modelcatalogue/core/ui/bs/bootstrap/custom/tables.less
@@ -1,0 +1,34 @@
+// Inline table w/ no padding
+
+.table-inline {
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        padding: 0;
+      }
+    }
+  }
+}
+
+// Table with no borders at all
+
+.table-borderless {
+  border: none;
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        border: none;
+      }
+    }
+  }
+}
+
+.table-no-margin {
+  margin-bottom: 0;
+}

--- a/ModelCatalogueCorePlugin/grails-app/assets/stylesheets/modelcatalogue/core/ui/bs/bootstrap/custom/type.less
+++ b/ModelCatalogueCorePlugin/grails-app/assets/stylesheets/modelcatalogue/core/ui/bs/bootstrap/custom/type.less
@@ -1,0 +1,4 @@
+.text-wrap {
+  word-wrap: break-word;
+  word-break: break-all; // this wraps long text in tables
+}


### PR DESCRIPTION
@musketyr 
- I've added some bootstrap enhancements: table-inline, table-borderless, table-no-margin and also text-wrap
- for me table layout makes the best sense here as the browser decides how much space it will give to key and value based on their length...