### PR TITLE
skip core.js processig by asset pipeline

### DIFF
--- a/ModelCatalogueCorePluginTestApp/grails-app/conf/Config.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/conf/Config.groovy
@@ -267,6 +267,7 @@ def assetExcludes = [
         "bootstrap/**/*.*",
         "jquery-ui/**/*.*",
         "font-awesome/**/*.*",
+        "core.js/**/*.*",
         "jquery/**/*.*",
         "angular/**/*.*",
         "ace-builds/**/*.*",

--- a/ModelCatalogueCorePluginTestApp/grails-app/views/index.gsp
+++ b/ModelCatalogueCorePluginTestApp/grails-app/views/index.gsp
@@ -50,8 +50,10 @@
         <script type="application/javascript" src="//cdnjs.cloudflare.com/ajax/libs/core-js/2.3.0/core${minSuffix}.js"></script>
         <script type="application/javascript" src="//cdnjs.cloudflare.com/ajax/libs/ace/1.2.3/ace.js"></script>
         <script type="application/javascript" src="//cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.8/rx.all${minSuffix}.js"></script>
+
         <!-- Saxon needs to be excluded from the main bulk but does not live in any CDN -->
         <asset:javascript src="saxonce/Saxonce.nocache.js"/>
+
         <script type="application/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery${minSuffix}.js"></script>
         <script type="application/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui${minSuffix}.js"></script>
         <script type="application/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/js/bootstrap${minSuffix}.js"></script>


### PR DESCRIPTION
it's referenced from cdn in production