### PR TITLE
soft reindex

### DIFF
--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/navigationRightActions.coffee
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/navigationRightActions.coffee
@@ -158,7 +158,7 @@ angular.module('mc.core.ui.bs.navigationRightActions', ['mc.util.ui.actions', 'm
       type: 'success'
       action: ->
         messages.confirm("Do you want to reindex catalogue?", "Whole catalogue will be reindexed. This may take a long time and it can have negative impact on the performance.").then ->
-          rest(url: "#{modelCatalogueApiRoot}/search/reindex", method: 'POST').then ->
+          rest(url: "#{modelCatalogueApiRoot}/search/reindex", method: 'POST', params: {soft: true}).then ->
             messages.success('Reindex Catalogue', 'Reindexing the catalogue scheduled.')
       }
   ]

--- a/ModelCatalogueCorePlugin/grails-app/controllers/org/modelcatalogue/core/SearchController.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/controllers/org/modelcatalogue/core/SearchController.groovy
@@ -40,9 +40,11 @@ class SearchController extends AbstractRestfulController<CatalogueElement> {
         }
 
         log.info "Reindexing search service ..."
+
+        boolean soft = params.boolean('soft')
         executorService.submit {
             profile(excludeMethods: ['rx.observables.BlockingObservable.subscribe', 'groovyx.gprof.Profiler.stop']) {
-                modelCatalogueSearchService.reindex().toBlocking().subscribe(LoggingSubscriber.create(log, "... reindexing finished", "Error reindexing the catalogue"))
+                modelCatalogueSearchService.reindex(soft).toBlocking().subscribe(LoggingSubscriber.create(log, "... reindexing finished", "Error reindexing the catalogue"))
             }.prettyPrint()
         }
 

--- a/ModelCatalogueCorePlugin/grails-app/services/org/modelcatalogue/core/ModelCatalogueSearchService.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/services/org/modelcatalogue/core/ModelCatalogueSearchService.groovy
@@ -189,7 +189,7 @@ class ModelCatalogueSearchService implements SearchCatalogue {
         Observable.just(true)
     }
 
-    Observable<Boolean> reindex()  {
+    Observable<Boolean> reindex(boolean soft)  {
         log.info "Using database search, reindexing not needed!"
         Observable.just(true)
     }

--- a/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/SearchCatalogue.groovy
+++ b/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/SearchCatalogue.groovy
@@ -14,7 +14,7 @@ public interface SearchCatalogue {
     Observable<Boolean> index(Iterable<Object> resource)
     Observable<Boolean> unindex(Object object)
     Observable<Boolean> unindex(Collection<Object> object)
-    Observable<Boolean> reindex()
+    Observable<Boolean> reindex(boolean soft)
 
     boolean isIndexingManually()
 

--- a/ModelCatalogueCorePluginTestApp/grails-app/conf/BootStrap.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/conf/BootStrap.groovy
@@ -34,7 +34,7 @@ class BootStrap {
                 initSecurity()
                 setupStuff()
             }
-            modelCatalogueSearchService.reindex().all { it }.toBlocking().subscribe {
+            modelCatalogueSearchService.reindex(true).all { it }.toBlocking().subscribe {
                 System.out.println "Reindexed"
             }
         } else {

--- a/ModelCatalogueCorePluginTestApp/grails-app/conf/Config.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/conf/Config.groovy
@@ -234,6 +234,7 @@ log4j.main = {
     debug 'org.modelcatalogue.discourse'
 
     info 'grails.app.services.org.grails.plugins.console'
+    info 'grails.app.services.org.modelcatalogue.core.elasticsearch'
     info 'org.grails.plugins.console'
 
     info 'org.modelcatalogue.core.rx.BatchOperator'

--- a/ModelCatalogueCorePluginTestApp/test/integration/org/modelcatalogue/core/elasticsearch/ElasticSearchServiceSpec.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/integration/org/modelcatalogue/core/elasticsearch/ElasticSearchServiceSpec.groovy
@@ -24,7 +24,7 @@ class ElasticSearchServiceSpec extends org.modelcatalogue.testapp.AbstractIntegr
         relationshipTypeService.clearCache()
 
         elasticSearchService.initLocalClient()
-        elasticSearchService.reindex().toBlocking().subscribe()
+        elasticSearchService.reindex(true).toBlocking().subscribe()
     }
 
     def "play with elasticsearch"() {
@@ -304,7 +304,7 @@ class ElasticSearchServiceSpec extends org.modelcatalogue.testapp.AbstractIntegr
         }.count() == 39
 
         when:
-        elasticSearchService.reindex().toBlocking().last()
+        elasticSearchService.reindex(true).toBlocking().last()
 
         then:
         noExceptionThrown()

--- a/ModelCatalogueElasticSearchPlugin/grails-app/services/org/modelcatalogue/core/elasticsearch/ElasticSearchService.groovy
+++ b/ModelCatalogueElasticSearchPlugin/grails-app/services/org/modelcatalogue/core/elasticsearch/ElasticSearchService.groovy
@@ -373,11 +373,11 @@ class ElasticSearchService implements SearchCatalogue {
             return indexExists(session, just(indexName)).flatMap {
                 if (it.exists) {
                     return RxElastic.from(client.admin().indices().prepareDelete(indexName)).map {
-                        log.debug "Deleted index $indexName"
+                        log.info "Deleted index $indexName"
                         session.indexExist(indexName, false)
                         return it.acknowledged
                     }.onErrorReturn { error ->
-                        log.debug "Exception deleting index $indexName: $error"
+                        log.warn "Exception deleting index $indexName: $error"
                         return false
                     }.concatWith(unindexInternal(session, object))
                 }
@@ -635,7 +635,7 @@ class ElasticSearchService implements SearchCatalogue {
                 if (!it.acknowledged) {
                     return ensureIndexExists(session, indices, supportedTypes)
                 }
-                log.info "Created index $response.index for following types: $supportedTypes"
+                log.debug "Created index $response.index for following types: $supportedTypes"
                 session.indexExist(response.index, true)
                 return just(response.index)
             } .onErrorReturn {


### PR DESCRIPTION
deleting the index and than recreating is causing problems. by default the index is not deleted on reindex but each element is indexed again which suits the use cases well as the primary use case for reindexing is to init empty elasticsearch instance with the data after SQL import. if you need to delete the indicies you can always start with fresh elasticsearch instance.